### PR TITLE
Add XML declaration to export template.

### DIFF
--- a/application/editor/views/scripts/export/xml.phtml
+++ b/application/editor/views/scripts/export/xml.phtml
@@ -20,6 +20,7 @@
  */
 ?>
 <?php if ($this->renderHeader):?>
+<?php echo '<?xml version="1.0" encoding="UTF-8"?>'?>
 	<rdf:RDF<?php foreach ($this->namespaces as $prefix => $uri):?> xmlns:<?php echo $prefix?>="<?php echo $uri?>"<?php endforeach ?>>
 <?php endif?>
 


### PR DESCRIPTION
This simply adds the XML declaration to the top of the XML export template.

Indentation is intentionally omitted so that in the output `<?xml` appears at the very start of the document.
